### PR TITLE
Fix mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import { createRoutingMiddleware } from 'direct-react-router';
 // ...
 const routerMiddleware = createRoutingMiddleware(config, history);
 // ...
-const store = createStore(rootReducer, routerMiddleware);
+const store = createStore(rootReducer, applyMiddleware(routerMiddleware));
 ```
 
 Теперь при каждом изменении url будет генериироваться action, который вы можете обрабатывать любым нужным способом. В него приходит информация о новом URL и его параметрах + его alias в конфиге.


### PR DESCRIPTION
In order to use the middleware, you have to turn it into a `StoreEnhancer` which is taken by the `createStore` function as the second parameter. This is done using `applyMiddleware` helper function.